### PR TITLE
Upgrade to glimmer-dsl-libui 0.12.1 fixing issue with concurrent-ruby 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'glimmer-dsl-libui', '~> 0.11.8'
+gem 'glimmer-dsl-libui', '~> 0.12.1'
 gem 'sqlite3', '~> 1.3'
 gem 'activerecord'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     glimmer (2.7.7)
       array_include_methods (>= 1.4.0, < 1.6.0)
       facets (>= 3.1.0, < 4.0.0)
-    glimmer-dsl-libui (0.11.8)
+    glimmer-dsl-libui (0.12.1)
       chunky_png (~> 1.4.0)
       color (~> 1.8)
       equalizer (= 0.0.11)
@@ -88,7 +88,7 @@ GEM
       libui (= 0.1.2.pre)
       os (>= 1.0.0, < 2.0.0)
       perfect-shape (~> 1.0.8)
-      puts_debuggerer (>= 0.13.5, < 2.0.0)
+      puts_debuggerer (>= 1.0.0, < 2.0.0)
       rake (>= 10.1.0, < 14.0.0)
       rake-tui (>= 0.2.3, < 2.0.0)
       rouge (>= 3.26.0, < 4.0.0)
@@ -228,7 +228,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   debug!
-  glimmer-dsl-libui (~> 0.11.8)
+  glimmer-dsl-libui (~> 0.12.1)
   juwelier (= 2.4.9)
   rspec (~> 3.5.0)
   simplecov

--- a/bin/glimmer_dsl_with_active_record
+++ b/bin/glimmer_dsl_with_active_record
@@ -1,15 +1,5 @@
 #!/usr/bin/env ruby
 
-begin
-  if Object.constants.include?(:Concurrent)
-    Object.send(:remove_const, :Concurrent)
-  end
-  require 'concurrent'
-rescue StandardError => e
-  puts "Oops from #{bin/glimmer_dsl_with_active_record}"
-  puts e.message
-  puts e.backtrace
-end
 runner = File.expand_path('../../app/glimmer_dsl_with_active_record/launch.rb', __FILE__)
 
 require 'glimmer/launcher'


### PR DESCRIPTION
I upgraded to glimmer-dsl-libui 0.12.1, fixing the issue with concurrent-ruby and removing the `bin/glimmer_dsl_with_active_record` Concurrent hack.